### PR TITLE
Update header recieving logic to notice peer disconnects.

### DIFF
--- a/eventwork_tcp/src/lib.rs
+++ b/eventwork_tcp/src/lib.rs
@@ -62,11 +62,27 @@ impl NetworkServerProvider for TcpServerProvider{
         let mut buffer = vec![0; settings.max_packet_length];
         loop {
             info!("Reading message length");
-            let length = match read_half.read_exact(&mut buffer[..8]).await {
-                Ok(len) => {
+            let length = match read_half.read(&mut buffer[..8]).await {
+                Ok(0) => {
+                    // EOF, meaning the TCP stream has closed.
+                    info!(
+                        "Client disconnected"
+                    );
+                    // TODO: probably want to do more than just quit the receive task.
+                    //       to let eventwork know that the peer disconnected.
+                    break;
+                }
+                Ok(8) => {
                     let bytes = &buffer[..8];
                     u64::from_le_bytes(bytes.try_into().unwrap()) as usize
                 },
+                Ok(n) => {
+                    error!(
+                        "Could not read enough bytes for header. Expected 8, got {}",
+                        n
+                    );
+                    break;
+                }
                 Err(err) => {
                     error!(
                         "Encountered error while fetching length: {}",
@@ -87,7 +103,7 @@ impl NetworkServerProvider for TcpServerProvider{
 
             info!("Reading message into buffer");
             match read_half.read_exact(&mut buffer[..length]).await {
-                Ok(_) => (),
+                Ok(()) => (),
                 Err(err) => {
                     error!(
                         "Encountered error while fetching stream of length {}: {}",
@@ -110,10 +126,10 @@ impl NetworkServerProvider for TcpServerProvider{
             };
 
             if let Err(_) = messages.send(packet).await{
-                error!("Failed to send decoded message to Spicy");
+                error!("Failed to send decoded message to eventwork");
                 break;
             }
-            info!("Message read");
+            info!("Message deserialized and sent to eventwork");
         }
     }
 


### PR DESCRIPTION
The receiving task in `eventwork_tcp` logs an error when the peer disconnects. Ideally, it would somehow let the client/server know that the peer disconnected. I think Spicy did this with an events channel.
I updated the header receive logic to give more descriptive error messages, and provided room to send a disconnect message or do something else on disconnect.