### PR TITLE
Update readme bevy compatibility table

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -95,7 +95,7 @@ Simply pick the version compatible to your bevy version:
 
 | Bevy Eventwork | Bevy |
 | :------------: | :--: |
-|      0.8       | 0.12 |
+|      0.8       | 0.13 |
 |      0.7       | 0.8  |
 
 Any version that is not compatible with the latest bevy version is in maintenance mode.


### PR DESCRIPTION
Updates the readme to correctly list bevy 0.13 support